### PR TITLE
fix scss-lint warnings

### DIFF
--- a/src/balloon.scss
+++ b/src/balloon.scss
@@ -2,7 +2,7 @@
 // Variables
 // -----------------------------------------
 
-$balloon-bg:             fade-out(#111, 0.1);
+$balloon-bg:             fade-out(#111, .1);
 $balloon-base-size:      10px;
 $balloon-arrow-height:   6px;
 
@@ -11,7 +11,7 @@ $balloon-arrow-height:   6px;
 // Mixins
 // -----------------------------------------
 
-@mixin svg-arrow($color, $position: "up") {
+@mixin svg-arrow($color, $position: up) {
 
     $degrees: 0;
     $height:  6px;
@@ -31,7 +31,7 @@ $balloon-arrow-height:   6px;
         $height: 18px;
     }
 
-    background: no-repeat url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="#{$width*2}" height="#{$height*2}"><path fill="#{$color}" transform="rotate(#{$degrees})" d="M2.658,0.000 C-13.615,0.000 50.938,0.000 34.662,0.000 C28.662,0.000 23.035,12.002 18.660,12.002 C14.285,12.002 8.594,0.000 2.658,0.000 Z"/></svg>');
+    background: no-repeat url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="#{$width * 2}" height="#{$height * 2}"><path fill="#{$color}" transform="rotate(#{$degrees})" d="M2.658,0.000 C-13.615,0.000 50.938,0.000 34.662,0.000 C28.662,0.000 23.035,12.002 18.660,12.002 C14.285,12.002 8.594,0.000 2.658,0.000 Z"/></svg>');
     background-size: 100% auto;
     width: $width;
     height: $height;
@@ -40,7 +40,7 @@ $balloon-arrow-height:   6px;
 @mixin base-effects() {
     opacity: 0;
     pointer-events: none;
-    transition:all 0.18s ease-out;
+    transition: all .18s ease-out;
 }
 
 
@@ -55,24 +55,24 @@ $balloon-arrow-height:   6px;
     &::before {
         @include base-effects();
 
-        z-index: 10;
-        white-space: nowrap;
-        font-size: $balloon-base-size + 2;
-        content: attr(data-balloon);
-        position: absolute;
-        color: #fff;
         background: $balloon-bg;
-        padding: .5em 1em;
         border-radius: 4px;
+        color: #fff;
+        content: attr(data-balloon);
+        font-size: $balloon-base-size + 2;
+        padding: .5em 1em;
+        position: absolute;
+        white-space: nowrap;
+        z-index: 10;
     }
 
     &::after {
         @include svg-arrow($balloon-bg);
         @include base-effects();
 
-        z-index: 10;
-        content:'';
+        content: '';
         position: absolute;
+        z-index: 10;
     }
 
     &:hover {
@@ -88,15 +88,14 @@ $balloon-arrow-height:   6px;
             bottom: 100%;
             left: 50%;
             margin-bottom: 5px + $balloon-arrow-height;
-
             transform: translate3d(-50%, 10px, 0);
             transform-origin: top;
         }
+
         &::after {
             bottom: 100%;
             left: 50%;
             margin-bottom: 5px;
-
             transform: translate3d(-50%, 10px, 0);
             transform-origin: top;
         }
@@ -110,19 +109,20 @@ $balloon-arrow-height:   6px;
         }
     }
 
-    &[data-balloon-pos="down"] {
+    &[data-balloon-pos='down'] {
         &::before {
-            top: 100%;
             left: 50%;
             margin-top: 5px + $balloon-arrow-height;
+            top: 100%;
             transform: translate3d(-50%, -10px, 0);
         }
-        &::after {
-            @include svg-arrow($balloon-bg, "down");
 
-            top: 100%;
+        &::after {
+            @include svg-arrow($balloon-bg, 'down');
+
             left: 50%;
             margin-top: 5px;
+            top: 100%;
             transform: translate3d(-50%, -10px, 0);
         }
 
@@ -135,20 +135,20 @@ $balloon-arrow-height:   6px;
         }
     }
 
-    &[data-balloon-pos="left"] {
+    &[data-balloon-pos='left'] {
         &::before {
-            top:50%;
-            right: 100%;
             margin-right: 5px + $balloon-arrow-height;
+            right: 100%;
+            top: 50%;
             transform: translate3d(10px, -50%, 0);
         }
 
         &::after {
-            @include svg-arrow($balloon-bg, "left");
+            @include svg-arrow($balloon-bg, 'left');
 
-            top:50%;
-            right: 100%;
             margin-right: 5px;
+            right: 100%;
+            top: 50%;
             transform: translate3d(10px, -50%, 0);
         }
 
@@ -161,21 +161,21 @@ $balloon-arrow-height:   6px;
         }
     }
 
-    &[data-balloon-pos="right"] {
+    &[data-balloon-pos='right'] {
         &::before {
 
-            top: 50%;
             left: 100%;
             margin-left: 5px + $balloon-arrow-height;
+            top: 50%;
             transform: translate3d(-10px, -50%, 0);
         }
 
         &::after {
-            @include svg-arrow($balloon-bg, "right");
+            @include svg-arrow($balloon-bg, 'right');
 
-            top: 50%;
             left: 100%;
             margin-left: 5px;
+            top: 50%;
             transform: translate3d(-10px, -50%, 0);
         }
 
@@ -188,38 +188,38 @@ $balloon-arrow-height:   6px;
         }
     }
 
-    &[data-balloon-length="small"] {
+    &[data-balloon-length='small'] {
         &::before {
+            white-space: normal;
             width: 80px;
-            white-space: normal;
         }
     }
 
-    &[data-balloon-length="medium"] {
+    &[data-balloon-length='medium'] {
         &::before {
+            white-space: normal;
             width: 150px;
-            white-space: normal;
         }
     }
 
-    &[data-balloon-length="large"] {
+    &[data-balloon-length='large'] {
         &::before {
+            white-space: normal;
             width: 260px;
-            white-space: normal;
         }
     }
 
-    &[data-balloon-length="xlarge"] {
+    &[data-balloon-length='xlarge'] {
         &::before {
+            white-space: normal;
             width: 380px;
-            white-space: normal;
         }
     }
 
-    &[data-balloon-length="fit"] {
+    &[data-balloon-length='fit'] {
         &::before {
-            width: 100%;
             white-space: normal;
+            width: 100%;
         }
     }
 }
@@ -227,10 +227,10 @@ $balloon-arrow-height:   6px;
 
 @media screen and (max-width: 768px) {
     [data-balloon] {
-        &[data-balloon-length="xlarge"] {
+        &[data-balloon-length='xlarge'] {
             &::before {
-                width: 90vw;
                 white-space: normal;
+                width: 90vw;
             }
         }
     }


### PR DESCRIPTION
- EmptyLineBetweenBlocks: Rule declaration should be followed by an empty line
- LeadingZero: `0.1` should be written without a leading zero as `.1`
- PropertySortOrder: Properties should be ordered
- SpaceAfterPropertyColon: Colon after property should be followed by one space
- SpaceAroundOperator: `$width*2` should be written with a single space on each side of the operator: `$width * 2`
- StringQuotes: Prefer single quoted strings

[Sass Guidelines](http://sass-guidelin.es/) also recommends using `two` spaces instead of `four` to indent.
@kazzkiq What do you think about it?
