### PR TITLE
Add mixins for transitions

### DIFF
--- a/src/balloon.scss
+++ b/src/balloon.scss
@@ -57,8 +57,16 @@ $balloon-arrow-height:   6px;
   transform-origin: $val;
 }
 
+@mixin opacity ($trans) {
+  filter: alpha(opactiy=($trans * 100));
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=#{$trans * 100})";
+  -moz-opacity: $trans;
+  -khtml-opacity: $trans;
+  opacity: $trans;
+}
+
 @mixin base-effects () {
-    opacity: 0;
+    @include opacity(0);
     pointer-events: none;
     @include transition(all .18s ease-out);
 }
@@ -98,7 +106,7 @@ $balloon-arrow-height:   6px;
     &:hover {
         &::before,
         &::after {
-            opacity: 1;
+            @include opacity(1);
             pointer-events: auto;
         }
     }

--- a/src/balloon.scss
+++ b/src/balloon.scss
@@ -41,6 +41,19 @@ $balloon-arrow-height:   6px;
     transition: all .18s ease-out;
 }
 
+@mixin transform ($val) {
+  -webkit-transform($val);
+  -moz-transform($val);
+  -ms-transform($val);
+  transform($val);
+}
+
+@mixin transform-origin ($val) {
+  -webkit-transform-origin: $val;
+  -moz-transform-origin: $val;
+  -ms-transform-origin: $val;
+  transform-origin: $val;
+}
 
 //
 // Styles
@@ -86,25 +99,25 @@ $balloon-arrow-height:   6px;
             bottom: 100%;
             left: 50%;
             margin-bottom: 5px + $balloon-arrow-height;
-            transform: translate3d(-50%, 10px, 0);
-            transform-origin: top;
+            @include transform(translate3d(-50%, 10px, 0));
+            @include transform-origin(top);
         }
 
         &::after {
             bottom: 100%;
             left: 50%;
             margin-bottom: 5px;
-            transform: translate3d(-50%, 10px, 0);
-            transform-origin: top;
+            @include transform(translate3d(-50%, 10px, 0));
+            @include transform-origin(top);
         }
 
         &:hover {
             &::before {
-                transform: translate3d(-50%, 0, 0);
+                @include transform(translate3d(-50%, 0, 0));
             }
 
             &::after {
-                transform: translate3d(-50%, 0, 0);
+                @include transform(translate3d(-50%, 0, 0));
             }
         }
 
@@ -115,7 +128,7 @@ $balloon-arrow-height:   6px;
             left: 50%;
             margin-top: 5px + $balloon-arrow-height;
             top: 100%;
-            transform: translate3d(-50%, -10px, 0);
+            @include transform(translate3d(-50%, -10px, 0));
         }
 
         &::after {
@@ -124,16 +137,16 @@ $balloon-arrow-height:   6px;
             left: 50%;
             margin-top: 5px;
             top: 100%;
-            transform: translate3d(-50%, -10px, 0);
+            @include transform(translate3d(-50%, -10px, 0));
         }
 
         &:hover {
             &::before {
-                transform: translate3d(-50%, 0, 0);
+                @include transform(translate3d(-50%, 0, 0));
             }
 
             &::after {
-                transform: translate3d(-50%, 0, 0);
+                @include transform(translate3d(-50%, 0, 0));
             }
         }
     }
@@ -143,7 +156,7 @@ $balloon-arrow-height:   6px;
             margin-right: 5px + $balloon-arrow-height;
             right: 100%;
             top: 50%;
-            transform: translate3d(10px, -50%, 0);
+            @include transform(translate3d(10px, -50%, 0));
         }
 
         &::after {
@@ -152,16 +165,16 @@ $balloon-arrow-height:   6px;
             margin-right: 5px;
             right: 100%;
             top: 50%;
-            transform: translate3d(10px, -50%, 0);
+            @include transform(translate3d(10px, -50%, 0));
         }
 
         &:hover {
             &::before {
-                transform: translate3d(0, -50%, 0);
+                @include transform(translate3d(0, -50%, 0));
             }
 
             &::after {
-                transform: translate3d(0, -50%, 0);
+                @include transform(translate3d(0, -50%, 0));
             }
         }
 
@@ -173,7 +186,7 @@ $balloon-arrow-height:   6px;
             left: 100%;
             margin-left: 5px + $balloon-arrow-height;
             top: 50%;
-            transform: translate3d(-10px, -50%, 0);
+            @include transform(translate3d(-10px, -50%, 0));
         }
 
         &::after {
@@ -182,16 +195,16 @@ $balloon-arrow-height:   6px;
             left: 100%;
             margin-left: 5px;
             top: 50%;
-            transform: translate3d(-10px, -50%, 0);
+            @include transform(translate3d(-10px, -50%, 0));
         }
 
         &:hover {
             &::before {
-                transform: translate3d(0, -50%, 0);
+                @include transform(translate3d(0, -50%, 0));
             }
 
             &::after {
-                transform: translate3d(0, -50%, 0);
+                @include transform(translate3d(0, -50%, 0));
             }
         }
     }

--- a/src/balloon.scss
+++ b/src/balloon.scss
@@ -11,7 +11,7 @@ $balloon-arrow-height:   6px;
 // Mixins
 // -----------------------------------------
 
-@mixin svg-arrow($color, $position: up) {
+@mixin svg-arrow ($color, $position: up) {
 
     $degrees: 0;
     $height:  6px;
@@ -35,10 +35,12 @@ $balloon-arrow-height:   6px;
     height: $height;
 }
 
-@mixin base-effects() {
-    opacity: 0;
-    pointer-events: none;
-    transition: all .18s ease-out;
+@mixin transition ($args...) {
+  -webkit-transition: $args;
+  -moz-transition: $args;
+  -ms-transition: $args;
+  -o-transition: $args;
+  transition: $args;
 }
 
 @mixin transform ($val) {
@@ -54,6 +56,13 @@ $balloon-arrow-height:   6px;
   -ms-transform-origin: $val;
   transform-origin: $val;
 }
+
+@mixin base-effects () {
+    opacity: 0;
+    pointer-events: none;
+    @include transition(all .18s ease-out);
+}
+
 
 //
 // Styles

--- a/src/balloon.scss
+++ b/src/balloon.scss
@@ -44,10 +44,10 @@ $balloon-arrow-height:   6px;
 }
 
 @mixin transform ($val) {
-  -webkit-transform($val);
-  -moz-transform($val);
-  -ms-transform($val);
-  transform($val);
+  -webkit-transform: $val;
+  -moz-transform: $val;
+  -ms-transform: $val;
+  transform: $val;
 }
 
 @mixin transform-origin ($val) {


### PR DESCRIPTION
Hello @kazzkiq 

I add mixins for the `transform` and `transform-origin`.
I added manually, instead of add a dependency as compass or compass/mixins, because Isn't a hard dependency, in case that we are using it in more places we can consider it.

Also this solves some IE problems 
https://github.com/kazzkiq/balloon.css/issues/10
