### PR TITLE
removes box-shadow from upper tooltip

### DIFF
--- a/src/balloon.scss
+++ b/src/balloon.scss
@@ -131,7 +131,6 @@ $balloon-arrow-height:   6px;
             margin-bottom: 5px;
             @include transform(translate(-50%, 10px));
             @include transform-origin(top);
-            box-shadow: inset 0 -1px 2px 0 rgba(red, 1);
         }
 
         &:hover {


### PR DESCRIPTION
There was a red box-shadow attribute on the .scss file which i think was there for debugging purposes. :smile: 
