### PR TITLE
Fixed IE11 Nor working on button element #38

### DIFF
--- a/src/balloon.less
+++ b/src/balloon.less
@@ -86,6 +86,7 @@
 
 [data-balloon] {
     position: relative; // alt. absolute or fixed
+    overflow: visible; // IE button tag
     &:before,
     &:after {
         .base-effects();

--- a/src/balloon.scss
+++ b/src/balloon.scss
@@ -79,6 +79,7 @@ $balloon-arrow-height:   6px;
 
 [data-balloon] {
     position: relative; // alt. absolute or fixed
+    overflow: visible; // IE button tag
 
     &:after {
         @include base-effects();


### PR DESCRIPTION
Funny bug - [link](https://stackoverflow.com/questions/30176560/css-after-doesnt-work-on-button-element-in-any-ie-version)
