### PR TITLE
Add sass variable defaults

### DIFF
--- a/src/balloon.scss
+++ b/src/balloon.scss
@@ -2,8 +2,8 @@
 // Variables
 // -----------------------------------------
 
-$balloon-bg:             fade-out(#111, .1);
-$balloon-base-size:      10px;
+$balloon-bg:             fade-out(#111, .1) !default;
+$balloon-base-size:      10px !default;
 $balloon-arrow-height:   6px;
 
 


### PR DESCRIPTION
Add [`!default` flag](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variable_defaults_) to variable definitions to allow manipulation from an external SASS file.

It would then be possible to load and customize [src/balloon.scss](https://github.com/kazzkiq/balloon.css/blob/master/src/balloon.scss) directly from another scss file:

```sass
/* customstyle.scss */
$balloon-bg:             fade-out(#F00, .25);
$balloon-base-size:      16px;

@import "~balloon-css/src/balloon";
```