### PR TITLE
Add jsDelivr links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,9 +22,11 @@ You also can check more examples at the website: http://kazzkiq.github.io/balloo
 npm install balloon-css
 ```
 
-**CDN version (provided by [cdnjs](https://github.com/cdnjs/cdnjs)):**
+**CDN version (provided by [cdnjs](https://github.com/cdnjs/cdnjs) and [jsDelivr](https://www.jsdelivr.com/package/npm/balloon-css)):**
 ```html
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/balloon-css/0.5.0/balloon.min.css">
+<!-- or -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/balloon-css@0.5.0/balloon.min.css">
 ```
 
 **Manually:**


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/balloon-css) to your readme as an alternative to cdnjs. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can instantly serve any project from npm with zero config and offers a large network and better reliability.