### PR TITLE
Fix broken variable assignment in SCSS source

### DIFF
--- a/src/balloon.scss
+++ b/src/balloon.scss
@@ -4,7 +4,7 @@
 
 $balloon-bg:             fade-out(#111, .1) !default;
 $balloon-base-size:      10px !default;
-$balloon-arrow-height:   6px !defaut;
+$balloon-arrow-height:   6px !default;
 
 
 //


### PR DESCRIPTION
"!default" keyword in the SCSS source file had a spelling error, resulting in SCSS parsing error.