### PR TITLE
Add word-break to enforce correct size

### DIFF
--- a/src/balloon.scss
+++ b/src/balloon.scss
@@ -96,6 +96,7 @@ button[aria-label] {
       padding: .5em 1em;
       position: absolute;
       white-space: nowrap;
+      word-break: break-all;
       z-index: 10;
     }
 


### PR DESCRIPTION
This is required to enforce the width of the tooltip when a word is very long (eg. displaying an URL inside a medium-sized tooltip)