### PR TITLE
split SASS code in separate files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "url": "https://github.com/kazzkiq/balloon.css.git"
   },
   "files": [
+    "src/_mixins.scss",
+    "src/_variables.scss",
     "src/balloon.scss",
     "balloon.css",
     "balloon.min.css"

--- a/src/_mixins.scss
+++ b/src/_mixins.scss
@@ -1,0 +1,47 @@
+@mixin arrow-down() {
+  width: 0;
+  height: 0;
+  border: $balloon-arrow-size solid transparent;
+  border-top-color: var(--balloon-color);
+}
+
+@mixin arrow-up() {
+  width: 0;
+  height: 0;
+  border: $balloon-arrow-size solid transparent;
+  border-bottom-color: var(--balloon-color);
+}
+
+@mixin arrow-left() {
+  width: 0;
+  height: 0;
+  border: $balloon-arrow-size solid transparent;
+  border-right-color: var(--balloon-color);
+}
+
+@mixin arrow-right() {
+  width: 0;
+  height: 0;
+  border: $balloon-arrow-size solid transparent;
+  border-left-color: var(--balloon-color);
+}
+
+@mixin base-effects() {
+  opacity: 0;
+  pointer-events: none;
+  transition: all 0.18s ease-out 0.18s;
+}
+
+@mixin no-effects() {
+  transition: none;
+}
+
+@mixin normalized-text() {
+  text-indent: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  font-weight: normal;
+  font-style: normal;
+  text-shadow: none;
+  font-size: var(--balloon-font-size);
+}

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,0 +1,4 @@
+$balloon-bg: fade-out(#101010, 0.05) !default;
+$balloon-base-size: 12px !default;
+$balloon-arrow-size: 5px !default;
+$balloon-move: 4px !default;

--- a/src/balloon.scss
+++ b/src/balloon.scss
@@ -2,62 +2,13 @@
 // Variables
 // -----------------------------------------
 
-$balloon-bg:             fade-out(#101010, .05) !default;
-$balloon-base-size:      12px !default;
-$balloon-arrow-size:     5px !default;
-$balloon-move:           4px !default;
-
+@import "./variables";
 
 //
 // Mixins
 // -----------------------------------------
 
-@mixin arrow-down() {
-  width: 0;
-  height: 0;
-  border: $balloon-arrow-size solid transparent;
-  border-top-color: var(--balloon-color);
-}
-
-@mixin arrow-up() {
-  width: 0;
-  height: 0;
-  border: $balloon-arrow-size solid transparent;
-  border-bottom-color: var(--balloon-color);
-}
-
-@mixin arrow-left() {
-  width: 0;
-  height: 0;
-  border: $balloon-arrow-size solid transparent;
-  border-right-color: var(--balloon-color);
-}
-
-@mixin arrow-right() {
-  width: 0;
-  height: 0;
-  border: $balloon-arrow-size solid transparent;
-  border-left-color: var(--balloon-color);
-}
-
-@mixin base-effects () {
-  opacity: 0;
-  pointer-events: none;
-  transition: all .18s ease-out .18s;
-}
-
-@mixin no-effects () {
-  transition: none;
-}
-
-@mixin normalized-text() {
-  text-indent: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  font-weight: normal;
-  font-style: normal;
-  text-shadow: none;
-  font-size: var(--balloon-font-size);
-}
+@import "./mixins";
 
 
 //


### PR DESCRIPTION
Allows users that use only balloon-mixins (and not balloon-classes) to avoid importing unused code.

My explicit goal is, on projects that don't use balloon-classes or `data-` attributes, to change `@import "../../node_modules/balloon-css/src/balloon";`by `import "../../node_modules/balloon-css/src/mixins";` which would result in a **8.2kB reduction of the minified output CSS**.

Also this is not a breaking change.