### PR TITLE
Use "help" cursor instead of "pointer"

### DIFF
--- a/src/balloon.scss
+++ b/src/balloon.scss
@@ -33,10 +33,7 @@ button[aria-label] {
 [aria-label] {
   &[data-balloon-pos] {
     position: relative; // alt. absolute or fixed
-
-    // Fixing iOS Safari event issue.
-    // More info at: https://goo.gl/w8JF4W
-    cursor: pointer;
+    cursor: help;
 
     &:after {
       @include base-effects();


### PR DESCRIPTION
I believe this is a more appropriate cursor as for tooltips. I read about the Safari bug in the comment, and I wasn't able to reproduce it on my iOS 13 / iPhone device nor my Macbook. It might be it's gone!

Please let me know what do you think. Keep up the good work!