### PR TITLE
Updated #L58 in test.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
         <p>By default, tooltips will always remain single-line no matter their length. You can change this behavior by using the attribute <code>data-balloon-length</code> with one of the values: <code>small</code>, <code>medium</code>, <code>large</code> or <code>fit</code>.</p>
 
         <div class="sample">
-          <pre><code class="language-markup">&lt;button data-balloon-length="small" aria-label="Hi." data-balloon-pos="up">Hover me!&lt;/button></code></pre>
+          <pre><code class="language-markup">&lt;button data-balloon-length="small" aria-label="Hi." data-balloon-pos="up">I'm a medium tooltip&lt;/button></code></pre>
           <div class="example">
             <button aria-label="Hi" data-balloon-pos="up" data-balloon-length="small">I'm a small tooltip</button>
           </div>


### PR DESCRIPTION
The example was showing `I'm a small tooltip` but In Code Example it was `Hover me!`

The correct fix for #159 